### PR TITLE
Fix issue #7: Add OnPhotoTapListener to PhilImageView

### DIFF
--- a/app/src/main/java/ml/fomi/apps/coloringbook/PhilImageView.java
+++ b/app/src/main/java/ml/fomi/apps/coloringbook/PhilImageView.java
@@ -29,7 +29,7 @@ import ml.fomi.apps.coloringbook.db.SectorsDAO;
  */
 public class PhilImageView extends VectorImageView implements PhotoView
 
-        .OnTouchListener, VectorImageView.OnImageCallbackListener, OnMatrixChangedListener {
+        .OnTouchListener, VectorImageView.OnImageCallbackListener, OnMatrixChangedListener, OnPhotoTapListener {
 
     private PhotoViewAttacher photoViewAttacher;
     private PhilImageView philImageView;
@@ -77,7 +77,7 @@ public class PhilImageView extends VectorImageView implements PhotoView
         photoViewAttacher.getDisplayMatrix(curMatrix);
         photoViewAttacher.setMaximumScale(18);
         photoViewAttacher.setMediumScale(6);
-        //photoViewAttacher.setOnPhotoTapListener(philImageView.setOnTouchListener(););
+        photoViewAttacher.setOnPhotoTapListener(philImageView);
         photoViewAttacher.setOnMatrixChangeListener(philImageView);
 
         paint = new Paint();
@@ -148,5 +148,11 @@ public class PhilImageView extends VectorImageView implements PhotoView
     @Override
     public boolean onTouch(View v, MotionEvent event) {
         return false;
+    }
+
+    @Override
+    public void onPhotoTap(android.widget.ImageView view, float x, float y) {
+        // Handle photo tap - can be used to trigger coloring at the tapped location
+        // x and y are percentages (0.0 to 1.0) of the drawable dimensions
     }
 }


### PR DESCRIPTION
## Summary
- Implements OnPhotoTapListener interface in PhilImageView class
- Sets photo tap listener on PhotoViewAttacher to enable tap detection
- Adds onPhotoTap method with placeholder for future tap handling logic

## Changes Made
- Added OnPhotoTapListener to the implements clause of PhilImageView
- Replaced commented out photoViewAttacher.setOnPhotoTapListener line with proper implementation
- Added onPhotoTap method implementation with documentation

## Test Plan
- [ ] Verify code compiles without errors (requires Java 17)
- [ ] Test that photo tap events are properly detected in the app
- [ ] Ensure existing touch functionality still works as expected

Fixes #7

🤖 Generated with [Claude Code](https://claude.ai/code)